### PR TITLE
Include function qualname in cache key to prevent same-module collisions

### DIFF
--- a/picocache/base.py
+++ b/picocache/base.py
@@ -129,7 +129,13 @@ class _BaseCache(ABC):
         @_copy_metadata(func)
         def wrapper(*args: Any, **kwargs: Any):
             # Pass the module name of the original function for key uniqueness
-            key = _make_key(args, kwargs, typed, module_name=func.__module__)
+            key = _make_key(
+                args,
+                kwargs,
+                typed,
+                module_name=func.__module__,
+                qualname=func.__qualname__,
+            )
 
             with lock:
                 # 1. Check persistent cache

--- a/picocache/django.py
+++ b/picocache/django.py
@@ -115,7 +115,13 @@ class DjangoCache(_BaseCache):
         @_copy_metadata(func)
         def wrapper(*args: Any, **kwargs: Any):
             # Use the same key generation as the base class
-            key = _make_key(args, kwargs, typed, module_name=func.__module__)
+            key = _make_key(
+                args,
+                kwargs,
+                typed,
+                module_name=func.__module__,
+                qualname=func.__qualname__,
+            )
 
             with lock:
                 # 1. Check persistent cache (Django backend)

--- a/picocache/utils.py
+++ b/picocache/utils.py
@@ -7,15 +7,25 @@ import pickle
 
 
 def _make_key(
-    args: Tuple[Any, ...], kwargs: Dict[str, Any], typed: bool, module_name: str
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    typed: bool,
+    module_name: str,
+    qualname: str,
 ) -> str:
     """Create a stable hashable key from call args/kwargs (mimics internal
     ``functools._make_key`` but returns hex digest for external storage).
 
-    Includes the module name to prevent collisions between functions in
-    different modules called with the same arguments.
+    Includes the module name and function qualname to prevent collisions
+    between functions in different modules *or* different functions within
+    the same module called with the same arguments.
+
+    .. note::
+        Adding ``qualname`` changes the SHA-256 digest for every key.
+        Existing persisted caches built with an older version of picocache
+        will be **invalidated** (one-time cold-start after upgrade).
     """
-    key_parts: Tuple[Any, ...] = (module_name,) + args
+    key_parts: Tuple[Any, ...] = (module_name, qualname) + args
     if kwargs:
         key_parts += (object(),)  # separator to avoid collisions
         for item in sorted(kwargs.items()):

--- a/tests/test_picocache.py
+++ b/tests/test_picocache.py
@@ -279,3 +279,34 @@ def test_maxsize_eviction(cache):
 
     # Clean up
     identity.cache_clear()
+
+
+def test_same_module_different_functions_no_collision(cache):
+    """Two functions in the same module with identical signatures must not share a cache key.
+
+    Regression test: before the fix, _make_key included module_name but not the
+    function qualname, so two functions in the same module called with the same
+    args hashed to the same key and g(5) silently returned f's cached result.
+    """
+    backend_name, cache_deco = cache
+
+    @cache_deco
+    def f(x: int) -> str:
+        return f"f:{x}"
+
+    @cache_deco
+    def g(x: int) -> str:
+        return f"g:{x}"
+
+    f.cache_clear()
+    g.cache_clear()
+
+    assert f(5) == "f:5"
+
+    result = g(5)
+    assert result == "g:5", (
+        f"[{backend_name}] cache collision: g(5) returned {result!r} instead of 'g:5'"
+    )
+
+    f.cache_clear()
+    g.cache_clear()


### PR DESCRIPTION
## Problem
`_make_key` built the cache key from `(module_name,) + args` (plus kwargs/types) but never included the function's identity. Two different functions in the same module, called with identical args, hash to the same key against the shared persistent store — so one silently returns the other's cached result. The docstring's stated goal (preventing cross-module collisions) didn't cover same-module collisions.

## Fix
Thread `func.__qualname__` into the key (prepended to `key_parts`); both call sites (`base.py`, `django.py`) updated. The other backends inherit `_BaseCache.__call__`, so they're covered transitively.

## Test
Added a regression test: two same-module functions with identical signatures must not share a cache entry. Fails pre-fix, passes post-fix (SQLite / SQLAlchemy / Django).

## Note
This changes the key digest, so existing persisted entries will miss once after upgrading (old entries become unreachable orphans, cleared by TTL/eviction). No data is corrupted.

Built with Claude Opus 4.8
